### PR TITLE
Add optional clientAssignedId

### DIFF
--- a/google_reminder_api_wrapper/reminder_api.py
+++ b/google_reminder_api_wrapper/reminder_api.py
@@ -28,7 +28,7 @@ class ReminderApi(ReminderApiBase):
 
         return self.request('list', '')
 
-    def create(self, title, due_date=''):
+    def create(self, title, due_date='', clientAssignedId=''):
         if not title:
             raise ValueError("Title can't be empty when creating reminder")
 
@@ -38,8 +38,12 @@ class ReminderApi(ReminderApiBase):
             },
             "task": {
                 "title": title
-            }
+            },
+            "taskId": {}
         }
+
+        if clientAssignedId:
+            payload['taskId']['clientAssignedId'] = clientAssignedId
 
         if due_date:
             payload['task']['dueDate'] = create_date_object(due_date)

--- a/google_reminder_api_wrapper/reminder_api.py
+++ b/google_reminder_api_wrapper/reminder_api.py
@@ -17,10 +17,10 @@ class ReminderApi(ReminderApiBase):
         }
 
         if task_id:
-            payload['taskId'][0]['serverAssignedId'] = task_id
+            payload['taskId'][0]['serverAssignedId'] = str(task_id)
 
         if clientAssignedId:
-            payload['taskId'][0]['clientAssignedId'] = clientAssignedId    
+            payload['taskId'][0]['clientAssignedId'] = str(clientAssignedId)    
 
         
         return self.request('get', payload)
@@ -54,7 +54,7 @@ class ReminderApi(ReminderApiBase):
         }
 
         if clientAssignedId:
-            payload['taskId']['clientAssignedId'] = clientAssignedId
+            payload['taskId']['clientAssignedId'] = str(clientAssignedId)
 
         if due_date:
             payload['task']['dueDate'] = create_date_object(due_date)

--- a/google_reminder_api_wrapper/reminder_api.py
+++ b/google_reminder_api_wrapper/reminder_api.py
@@ -6,17 +6,18 @@ class ReminderApi(ReminderApiBase):
     def __init__(self):
         super().__init__()
 
-    def get(self, serverAssignedId='', clientAssignedId=''):
+    def get(self, task_id='', clientAssignedId=''):
+        # task_id = serverAssignedId to ensure backwards compatbility
 
-        if not serverAssignedId and not clientAssignedId:
+        if not task_id and not clientAssignedId:
             raise ValueError("serverAssignedId and clientAssignedId can't both be empty")
 
         payload = {
             "taskId": [{}]
         }
 
-        if serverAssignedId:
-            payload['taskId'][0]['serverAssignedId'] = serverAssignedId
+        if task_id:
+            payload['taskId'][0]['serverAssignedId'] = task_id
 
         if clientAssignedId:
             payload['taskId'][0]['clientAssignedId'] = clientAssignedId    

--- a/google_reminder_api_wrapper/reminder_api.py
+++ b/google_reminder_api_wrapper/reminder_api.py
@@ -6,12 +6,22 @@ class ReminderApi(ReminderApiBase):
     def __init__(self):
         super().__init__()
 
-    def get(self, task_id):
+    def get(self, serverAssignedId='', clientAssignedId=''):
+
+        if not serverAssignedId and not clientAssignedId:
+            raise ValueError("serverAssignedId and clientAssignedId can't both be empty")
+
         payload = {
-            "taskId": [{
-                "serverAssignedId": str(task_id)
-            }]
+            "taskId": [{}]
         }
+
+        if serverAssignedId:
+            payload['taskId'][0]['serverAssignedId'] = serverAssignedId
+
+        if clientAssignedId:
+            payload['taskId'][0]['clientAssignedId'] = clientAssignedId    
+
+        
         return self.request('get', payload)
 
     def list(self):


### PR DESCRIPTION
These changes give developers the option to set the ID for a task when creating it. (and get() by this ID)
This enables tracking of the reminders created by your apps on the server-side, not just locally. (in case you lose your local files)
The changes are backwards compatible, because all changes are optional and the serverAssignedId is still the prefered method.